### PR TITLE
A little fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,12 @@
-require('fs').mkdirSync(__dirname+"/test/results/");
-
 module.exports = function(grunt) {
+  var testResultDir = __dirname + '/test/results/';
+
+  grunt.file.mkdir(testResultDir);
 
   require("matchdep").filterDev("grunt-*").forEach(grunt.loadNpmTasks);
 
   grunt.initConfig({
-    temp: __dirname+"/test/results/",
+    testResult: testResultDir,
 
     bump: {
       options: {
@@ -23,7 +24,7 @@ module.exports = function(grunt) {
     },
 
     clean: {
-      tests: ["<%= temp %>*"],
+      tests: ["<%= testResult %>*"]
     },
 
     svgicons2svgfont: {
@@ -34,7 +35,7 @@ module.exports = function(grunt) {
           appendCodepoints: true
         },
         src: "test/fixtures/prefixedicons/*.svg",
-        dest: "<%= temp %>"
+        dest: "<%= testResult %>"
       },
       testoriginalicons: {
         options: {
@@ -42,7 +43,7 @@ module.exports = function(grunt) {
           onlyFonts: true
         },
         src: "test/fixtures/originalicons/*.svg",
-        dest: "<%= temp %>"
+        dest: "<%= testResult %>"
       },
       testcleanicons: {
         options: {
@@ -50,12 +51,12 @@ module.exports = function(grunt) {
           onlyFonts: false
         },
         src: "test/fixtures/cleanicons/*.svg",
-        dest: "<%= temp %>"
+        dest: "<%= testResult %>"
       }
     },
 
     nodeunit: {
-      tests: ["test/*.nodeunit.js"],
+      tests: ["test/*.nodeunit.js"]
     }
   });
 

--- a/tasks/svgicons2svgfont.js
+++ b/tasks/svgicons2svgfont.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
     var done = this.async();
     this.files.forEach(function (files) {
       var usedCodePoints = []
-      , curCodepoint = 0xE001
+      , curCodepoint = UNICODE_PRIVATE_USE_AREA.start
       , fontDestination = Path.join(files.dest, options.font);
       
       svgicons2svgfont(files.src.map(function(file) {


### PR DESCRIPTION
- Use `grunt.file.mkdir` instead of `fs.mkdirSync`

Because `fs.mkdirSync` will throw error when the directory exists, and
that's really a trouble that i must remove '/test/results/' directory
when i run `grunt test` every second time.

- Use your const variable `UNICODE_PRIVATE_USE_AREA` instead of magic
number `0xE001`

And i wanna push a pull request to let this plugin support all options that your svgicons2svgfont project have. Could i ?